### PR TITLE
Support for multiple url caches, custom protocol name and using comt source as tilejson url

### DIFF
--- a/packages/maplibre-provider/src/index.ts
+++ b/packages/maplibre-provider/src/index.ts
@@ -19,8 +19,47 @@ export enum TileFetchStrategy {
  *   So with the first initial fetch all the unfragmented part of the index has to be fetched and can't be lazy loaded.
  */
 export class MapLibreComtProvider {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    private constructor() {}
+
+    comtCaches: Map<string, ComtCache>;
+    tileFetchStrategy: string;
+    
+    private constructor(tileFetchStrategy = TileFetchStrategy.BATCHED) {
+        this.comtCaches = new Map();
+        this.tileFetchStrategy = tileFetchStrategy === TileFetchStrategy.BATCHED ? 'getTileWithBatchRequest' : 'getTile';
+    }
+
+    getCache(url) {
+        if (!this.comtCaches.has(url)) {
+            this.comtCaches.set(url, ComtCache.createSync(url));
+        }
+        return this.comtCaches.get(url);
+    }
+
+    protocol = (params, callback) => {
+        if (params.type === 'json') {
+            const tilejson = { tiles: [params.url + "/{z}/{x}/{y}"] }
+            callback(null, tilejson, null, null);
+            return {
+                cancel: () => {},
+            };
+        }
+        else {
+            const cancellationToken = new CancellationToken();
+            const [, url, z, x, y] = params.url.match(/\/\/(.+)\/(\d+)\/(\d+)\/(\d+)/);
+            const xyzIndex = {
+                x: parseInt(x, 10),
+                y: parseInt(y, 10),
+                z: parseInt(z, 10),
+            };
+            this.getCache(url)[this.tileFetchStrategy](xyzIndex, cancellationToken)
+                .then((tile) => callback(null, tile, null, null));
+            return {
+                cancel: () => {
+                    cancellationToken.cancel();
+                },
+            };
+        }
+    }
 
     /**
      * Adds a COMT provider to MapLibre for displaying the map tiles of a COMTiles archive.
@@ -28,48 +67,7 @@ export class MapLibreComtProvider {
      *
      * @param tileFetchStrategy Specifies if the tiles should be fetched in batches or tile by tile.
      */
-    static register(tileFetchStrategy = TileFetchStrategy.BATCHED): void {
-        let comtCache: ComtCache;
-        let fetchTiles: (index: XyzIndex, token: CancellationToken) => Promise<Uint8Array>;
-        maplibregl.addProtocol("comt", (params, tileHandler) => {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const [tileUrl, url, z, x, y] = params.url.match(/comt:\/\/(.+)\/(\d+)\/(\d+)\/(\d+)/);
-            const cancellationToken = new CancellationToken();
-            const xyzIndex = {
-                x: parseInt(x, 10),
-                y: parseInt(y, 10),
-                z: parseInt(z, 10),
-            };
-
-            if (!comtCache) {
-                ComtCache.create(url, HeaderFetchStrategy.LAZY).then((cache) => {
-                    comtCache = cache;
-
-                    fetchTiles = (
-                        tileFetchStrategy === TileFetchStrategy.BATCHED
-                            ? comtCache.getTileWithBatchRequest
-                            : comtCache.getTile
-                    ).bind(comtCache);
-                    MapLibreComtProvider.fetchTile(xyzIndex, tileHandler, cancellationToken, fetchTiles);
-                });
-            } else {
-                MapLibreComtProvider.fetchTile(xyzIndex, tileHandler, cancellationToken, fetchTiles);
-            }
-
-            return {
-                cancel: () => {
-                    cancellationToken.cancel();
-                },
-            };
-        });
-    }
-
-    private static fetchTile(
-        xyzIndex: XyzIndex,
-        tileHandler,
-        cancellationToken: CancellationToken,
-        fetchTiles: (index: XyzIndex, token: CancellationToken) => Promise<Uint8Array>,
-    ): void {
-        fetchTiles(xyzIndex, cancellationToken).then((tile) => tileHandler(null, tile, null, null));
+    register(): void {
+        maplibregl.addProtocol("comt", this.protocol);
     }
 }

--- a/packages/maplibre-provider/src/index.ts
+++ b/packages/maplibre-provider/src/index.ts
@@ -29,10 +29,12 @@ export class MapLibreComtProvider {
     }
 
     getCache(url) {
-        if (!this.comtCaches.has(url)) {
-            this.comtCaches.set(url, ComtCache.createSync(url));
+        let cache = this.comtCaches.get(url);
+        if (!cache) {
+            cache = ComtCache.createSync(url);
+            this.comtCaches.set(url, cache);
         }
-        return this.comtCaches.get(url);
+        return cache;
     }
 
     protocol = (params, callback) => {

--- a/packages/maplibre-provider/src/index.ts
+++ b/packages/maplibre-provider/src/index.ts
@@ -66,8 +66,6 @@ export class MapLibreComtProvider {
     /**
      * Adds a COMT provider to MapLibre for displaying the map tiles of a COMTiles archive.
      * The COMT provider will be used when a source with a comt:// schema is used in a Mapbox style.
-     *
-     * @param tileFetchStrategy Specifies if the tiles should be fetched in batches or tile by tile.
      */
     register(): void {
         maplibregl.addProtocol("comt", this.protocol);

--- a/packages/maplibre-provider/src/index.ts
+++ b/packages/maplibre-provider/src/index.ts
@@ -23,7 +23,7 @@ export class MapLibreComtProvider {
     comtCaches: Map<string, ComtCache>;
     tileFetchStrategy: string;
     
-    private constructor(tileFetchStrategy = TileFetchStrategy.BATCHED) {
+    constructor(tileFetchStrategy = TileFetchStrategy.BATCHED) {
         this.comtCaches = new Map();
         this.tileFetchStrategy = tileFetchStrategy === TileFetchStrategy.BATCHED ? 'getTileWithBatchRequest' : 'getTile';
     }

--- a/packages/provider/src/comtCache.ts
+++ b/packages/provider/src/comtCache.ts
@@ -127,6 +127,14 @@ export default class ComtCache {
     }
 
     /**
+     * @param comtUrl Url to object storage where the COMTiles archive is hosted.
+     * @param throttleTime Time to wait for batching up the tile requests.
+     */
+    static createSync(comtUrl: string, throttleTime = 5): ComtCache {
+        return new ComtCache(comtUrl, throttleTime);
+    }
+
+    /**
      * Fetches a map tile with the given XYZ index from the specified COMTiles archive.
      *
      * @param xyzIndex Index of the tile in the XYZ tiling scheme.


### PR DESCRIPTION
The current Maplibre protocol implementation has some flaws that this PR tries to address.

1. From my understanding, the current comtCache object is overriden each time a new root `comt` source url is accessed, meaning that having two maps instanciated from the same global `maplibre` object and showing two different `comt` files would have their tile caches overwriten each time the other map would request a tile.

2. It's currently not possible to choose the name the protocol will be added with.

3. A `comt` source must be added within the vector source `tiles` array property, and cannot be added with the `url` property.

4. The `tileFetchStrategy` check for `BATCHED` or `SINGLE` was included inside the custom protocol function, which adds an avoidable overhead. The check is now moved in the provider constructor.


Previously:
```js
MapLibreComtProvider.register(TileFetchStrategy.SINGLE)
```
Now:
```js
const provider = new MapLibreComtProvider(TileFetchStrategy.SINGLE)
provider.register()
// or
maplibregl.addProtocol('com-tiles', provider.protocol)
```

Previously possible:
```json
"test-source": {
    "type": "vector",
    "tiles": [
      "comt://http://0.0.0.0:9000/comtiles/test.comt/{z}/{x}/{y}"
    ]
}
```
Now also possible 
```json
"test-source": {
    "type": "vector",
    "url":  "comt://http://0.0.0.0:9000/comtiles/test.comt"
}
```

I would happily discuss the propositions made and the implementation details.